### PR TITLE
Add Adonis migration/model generator

### DIFF
--- a/adonis/app/Models/AccessTokens.ts
+++ b/adonis/app/Models/AccessTokens.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class AccessTokens extends BaseModel {
+  public static table = 'access_tokens';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/AccountUsers.ts
+++ b/adonis/app/Models/AccountUsers.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class AccountUsers extends BaseModel {
+  public static table = 'account_users';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Accounts.ts
+++ b/adonis/app/Models/Accounts.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Accounts extends BaseModel {
+  public static table = 'accounts';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ActionMailboxInboundEmails.ts
+++ b/adonis/app/Models/ActionMailboxInboundEmails.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ActionMailboxInboundEmails extends BaseModel {
+  public static table = 'action_mailbox_inbound_emails';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ActiveStorageAttachments.ts
+++ b/adonis/app/Models/ActiveStorageAttachments.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ActiveStorageAttachments extends BaseModel {
+  public static table = 'active_storage_attachments';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ActiveStorageBlobs.ts
+++ b/adonis/app/Models/ActiveStorageBlobs.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ActiveStorageBlobs extends BaseModel {
+  public static table = 'active_storage_blobs';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ActiveStorageVariantRecords.ts
+++ b/adonis/app/Models/ActiveStorageVariantRecords.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ActiveStorageVariantRecords extends BaseModel {
+  public static table = 'active_storage_variant_records';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/AgentBotInboxes.ts
+++ b/adonis/app/Models/AgentBotInboxes.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class AgentBotInboxes extends BaseModel {
+  public static table = 'agent_bot_inboxes';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/AgentBots.ts
+++ b/adonis/app/Models/AgentBots.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class AgentBots extends BaseModel {
+  public static table = 'agent_bots';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/AppliedSlas.ts
+++ b/adonis/app/Models/AppliedSlas.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class AppliedSlas extends BaseModel {
+  public static table = 'applied_slas';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ArticleEmbeddings.ts
+++ b/adonis/app/Models/ArticleEmbeddings.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ArticleEmbeddings extends BaseModel {
+  public static table = 'article_embeddings';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Articles.ts
+++ b/adonis/app/Models/Articles.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Articles extends BaseModel {
+  public static table = 'articles';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Attachments.ts
+++ b/adonis/app/Models/Attachments.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Attachments extends BaseModel {
+  public static table = 'attachments';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Audits.ts
+++ b/adonis/app/Models/Audits.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Audits extends BaseModel {
+  public static table = 'audits';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/AutomationRules.ts
+++ b/adonis/app/Models/AutomationRules.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class AutomationRules extends BaseModel {
+  public static table = 'automation_rules';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Campaigns.ts
+++ b/adonis/app/Models/Campaigns.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Campaigns extends BaseModel {
+  public static table = 'campaigns';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/CannedResponses.ts
+++ b/adonis/app/Models/CannedResponses.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class CannedResponses extends BaseModel {
+  public static table = 'canned_responses';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/CaptainAssistantResponses.ts
+++ b/adonis/app/Models/CaptainAssistantResponses.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class CaptainAssistantResponses extends BaseModel {
+  public static table = 'captain_assistant_responses';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/CaptainAssistants.ts
+++ b/adonis/app/Models/CaptainAssistants.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class CaptainAssistants extends BaseModel {
+  public static table = 'captain_assistants';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/CaptainDocuments.ts
+++ b/adonis/app/Models/CaptainDocuments.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class CaptainDocuments extends BaseModel {
+  public static table = 'captain_documents';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/CaptainInboxes.ts
+++ b/adonis/app/Models/CaptainInboxes.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class CaptainInboxes extends BaseModel {
+  public static table = 'captain_inboxes';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Categories.ts
+++ b/adonis/app/Models/Categories.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Categories extends BaseModel {
+  public static table = 'categories';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ChannelApi.ts
+++ b/adonis/app/Models/ChannelApi.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ChannelApi extends BaseModel {
+  public static table = 'channel_api';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ChannelEmail.ts
+++ b/adonis/app/Models/ChannelEmail.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ChannelEmail extends BaseModel {
+  public static table = 'channel_email';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ChannelFacebookPages.ts
+++ b/adonis/app/Models/ChannelFacebookPages.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ChannelFacebookPages extends BaseModel {
+  public static table = 'channel_facebook_pages';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ChannelInstagram.ts
+++ b/adonis/app/Models/ChannelInstagram.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ChannelInstagram extends BaseModel {
+  public static table = 'channel_instagram';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ChannelLine.ts
+++ b/adonis/app/Models/ChannelLine.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ChannelLine extends BaseModel {
+  public static table = 'channel_line';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ChannelSms.ts
+++ b/adonis/app/Models/ChannelSms.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ChannelSms extends BaseModel {
+  public static table = 'channel_sms';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ChannelTelegram.ts
+++ b/adonis/app/Models/ChannelTelegram.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ChannelTelegram extends BaseModel {
+  public static table = 'channel_telegram';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ChannelTwilioSms.ts
+++ b/adonis/app/Models/ChannelTwilioSms.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ChannelTwilioSms extends BaseModel {
+  public static table = 'channel_twilio_sms';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ChannelTwitterProfiles.ts
+++ b/adonis/app/Models/ChannelTwitterProfiles.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ChannelTwitterProfiles extends BaseModel {
+  public static table = 'channel_twitter_profiles';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ChannelWebWidgets.ts
+++ b/adonis/app/Models/ChannelWebWidgets.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ChannelWebWidgets extends BaseModel {
+  public static table = 'channel_web_widgets';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ChannelWhatsapp.ts
+++ b/adonis/app/Models/ChannelWhatsapp.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ChannelWhatsapp extends BaseModel {
+  public static table = 'channel_whatsapp';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ContactInboxes.ts
+++ b/adonis/app/Models/ContactInboxes.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ContactInboxes extends BaseModel {
+  public static table = 'contact_inboxes';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Contacts.ts
+++ b/adonis/app/Models/Contacts.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Contacts extends BaseModel {
+  public static table = 'contacts';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ConversationParticipants.ts
+++ b/adonis/app/Models/ConversationParticipants.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ConversationParticipants extends BaseModel {
+  public static table = 'conversation_participants';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Conversations.ts
+++ b/adonis/app/Models/Conversations.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Conversations extends BaseModel {
+  public static table = 'conversations';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/CopilotMessages.ts
+++ b/adonis/app/Models/CopilotMessages.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class CopilotMessages extends BaseModel {
+  public static table = 'copilot_messages';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/CopilotThreads.ts
+++ b/adonis/app/Models/CopilotThreads.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class CopilotThreads extends BaseModel {
+  public static table = 'copilot_threads';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/CsatSurveyResponses.ts
+++ b/adonis/app/Models/CsatSurveyResponses.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class CsatSurveyResponses extends BaseModel {
+  public static table = 'csat_survey_responses';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/CustomAttributeDefinitions.ts
+++ b/adonis/app/Models/CustomAttributeDefinitions.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class CustomAttributeDefinitions extends BaseModel {
+  public static table = 'custom_attribute_definitions';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/CustomFilters.ts
+++ b/adonis/app/Models/CustomFilters.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class CustomFilters extends BaseModel {
+  public static table = 'custom_filters';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/CustomRoles.ts
+++ b/adonis/app/Models/CustomRoles.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class CustomRoles extends BaseModel {
+  public static table = 'custom_roles';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/DashboardApps.ts
+++ b/adonis/app/Models/DashboardApps.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class DashboardApps extends BaseModel {
+  public static table = 'dashboard_apps';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/DataImports.ts
+++ b/adonis/app/Models/DataImports.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class DataImports extends BaseModel {
+  public static table = 'data_imports';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/EmailTemplates.ts
+++ b/adonis/app/Models/EmailTemplates.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class EmailTemplates extends BaseModel {
+  public static table = 'email_templates';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Folders.ts
+++ b/adonis/app/Models/Folders.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Folders extends BaseModel {
+  public static table = 'folders';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/InboxMembers.ts
+++ b/adonis/app/Models/InboxMembers.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class InboxMembers extends BaseModel {
+  public static table = 'inbox_members';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Inboxes.ts
+++ b/adonis/app/Models/Inboxes.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Inboxes extends BaseModel {
+  public static table = 'inboxes';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/InstallationConfigs.ts
+++ b/adonis/app/Models/InstallationConfigs.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class InstallationConfigs extends BaseModel {
+  public static table = 'installation_configs';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/IntegrationsHooks.ts
+++ b/adonis/app/Models/IntegrationsHooks.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class IntegrationsHooks extends BaseModel {
+  public static table = 'integrations_hooks';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Labels.ts
+++ b/adonis/app/Models/Labels.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Labels extends BaseModel {
+  public static table = 'labels';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Macros.ts
+++ b/adonis/app/Models/Macros.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Macros extends BaseModel {
+  public static table = 'macros';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Mentions.ts
+++ b/adonis/app/Models/Mentions.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Mentions extends BaseModel {
+  public static table = 'mentions';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Messages.ts
+++ b/adonis/app/Models/Messages.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Messages extends BaseModel {
+  public static table = 'messages';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Notes.ts
+++ b/adonis/app/Models/Notes.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Notes extends BaseModel {
+  public static table = 'notes';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/NotificationSettings.ts
+++ b/adonis/app/Models/NotificationSettings.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class NotificationSettings extends BaseModel {
+  public static table = 'notification_settings';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/NotificationSubscriptions.ts
+++ b/adonis/app/Models/NotificationSubscriptions.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class NotificationSubscriptions extends BaseModel {
+  public static table = 'notification_subscriptions';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Notifications.ts
+++ b/adonis/app/Models/Notifications.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Notifications extends BaseModel {
+  public static table = 'notifications';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/PlatformAppPermissibles.ts
+++ b/adonis/app/Models/PlatformAppPermissibles.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class PlatformAppPermissibles extends BaseModel {
+  public static table = 'platform_app_permissibles';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/PlatformApps.ts
+++ b/adonis/app/Models/PlatformApps.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class PlatformApps extends BaseModel {
+  public static table = 'platform_apps';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Portals.ts
+++ b/adonis/app/Models/Portals.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Portals extends BaseModel {
+  public static table = 'portals';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/PortalsMembers.ts
+++ b/adonis/app/Models/PortalsMembers.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class PortalsMembers extends BaseModel {
+  public static table = 'portals_members';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/RelatedCategories.ts
+++ b/adonis/app/Models/RelatedCategories.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class RelatedCategories extends BaseModel {
+  public static table = 'related_categories';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/ReportingEvents.ts
+++ b/adonis/app/Models/ReportingEvents.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class ReportingEvents extends BaseModel {
+  public static table = 'reporting_events';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/SlaEvents.ts
+++ b/adonis/app/Models/SlaEvents.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class SlaEvents extends BaseModel {
+  public static table = 'sla_events';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/SlaPolicies.ts
+++ b/adonis/app/Models/SlaPolicies.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class SlaPolicies extends BaseModel {
+  public static table = 'sla_policies';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Taggings.ts
+++ b/adonis/app/Models/Taggings.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Taggings extends BaseModel {
+  public static table = 'taggings';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Tags.ts
+++ b/adonis/app/Models/Tags.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Tags extends BaseModel {
+  public static table = 'tags';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/TeamMembers.ts
+++ b/adonis/app/Models/TeamMembers.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class TeamMembers extends BaseModel {
+  public static table = 'team_members';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Teams.ts
+++ b/adonis/app/Models/Teams.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Teams extends BaseModel {
+  public static table = 'teams';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/TelegramBots.ts
+++ b/adonis/app/Models/TelegramBots.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class TelegramBots extends BaseModel {
+  public static table = 'telegram_bots';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Users.ts
+++ b/adonis/app/Models/Users.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Users extends BaseModel {
+  public static table = 'users';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/Webhooks.ts
+++ b/adonis/app/Models/Webhooks.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class Webhooks extends BaseModel {
+  public static table = 'webhooks';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/app/Models/WorkingHours.ts
+++ b/adonis/app/Models/WorkingHours.ts
@@ -1,0 +1,8 @@
+import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'
+
+export default class WorkingHours extends BaseModel {
+  public static table = 'working_hours';
+
+  @column({ isPrimary: true })
+  public id: number
+}

--- a/adonis/database/migrations/17511704737791_access_tokens.ts
+++ b/adonis/database/migrations/17511704737791_access_tokens.ts
@@ -1,0 +1,20 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class AccessTokens extends BaseSchema {
+  protected tableName = 'access_tokens';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('owner_type')
+      table.bigInteger('owner_id')
+      table.string('token')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378010_applied_slas.ts
+++ b/adonis/database/migrations/175117047378010_applied_slas.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class AppliedSlas extends BaseSchema {
+  protected tableName = 'applied_slas';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('account_id')
+      table.bigInteger('sla_policy_id')
+      table.bigInteger('conversation_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.integer('sla_status')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/17511704737802_account_users.ts
+++ b/adonis/database/migrations/17511704737802_account_users.ts
@@ -1,0 +1,25 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class AccountUsers extends BaseSchema {
+  protected tableName = 'account_users';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('account_id')
+      table.bigInteger('user_id')
+      table.integer('role')
+      table.bigInteger('inviter_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.timestamp('active_at')
+      table.integer('availability')
+      table.boolean('auto_offline')
+      table.bigInteger('custom_role_id')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/17511704737803_accounts.ts
+++ b/adonis/database/migrations/17511704737803_accounts.ts
@@ -1,0 +1,28 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Accounts extends BaseSchema {
+  protected tableName = 'accounts';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.integer('locale')
+      table.string('domain')
+      table.string('support_email')
+      table.bigInteger('feature_flags')
+      table.integer('auto_resolve_duration')
+      table.jsonb('limits')
+      table.jsonb('custom_attributes')
+      table.integer('status')
+      table.jsonb('internal_attributes')
+      table.jsonb('settings')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/17511704737804_action_mailbox_inbound_emails.ts
+++ b/adonis/database/migrations/17511704737804_action_mailbox_inbound_emails.ts
@@ -1,0 +1,20 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ActionMailboxInboundEmails extends BaseSchema {
+  protected tableName = 'action_mailbox_inbound_emails';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('status')
+      table.string('message_id')
+      table.string('message_checksum')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/17511704737805_active_storage_attachments.ts
+++ b/adonis/database/migrations/17511704737805_active_storage_attachments.ts
@@ -1,0 +1,20 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ActiveStorageAttachments extends BaseSchema {
+  protected tableName = 'active_storage_attachments';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.string('record_type')
+      table.bigInteger('record_id')
+      table.bigInteger('blob_id')
+      table.timestamp('created_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/17511704737806_active_storage_blobs.ts
+++ b/adonis/database/migrations/17511704737806_active_storage_blobs.ts
@@ -1,0 +1,23 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ActiveStorageBlobs extends BaseSchema {
+  protected tableName = 'active_storage_blobs';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('key')
+      table.string('filename')
+      table.string('content_type')
+      table.text('metadata')
+      table.bigInteger('byte_size')
+      table.string('checksum')
+      table.timestamp('created_at')
+      table.string('service_name')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/17511704737807_active_storage_variant_records.ts
+++ b/adonis/database/migrations/17511704737807_active_storage_variant_records.ts
@@ -1,0 +1,17 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ActiveStorageVariantRecords extends BaseSchema {
+  protected tableName = 'active_storage_variant_records';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('blob_id')
+      table.string('variation_digest')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/17511704737808_agent_bot_inboxes.ts
+++ b/adonis/database/migrations/17511704737808_agent_bot_inboxes.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class AgentBotInboxes extends BaseSchema {
+  protected tableName = 'agent_bot_inboxes';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('inbox_id')
+      table.integer('agent_bot_id')
+      table.integer('status')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.integer('account_id')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/17511704737809_agent_bots.ts
+++ b/adonis/database/migrations/17511704737809_agent_bots.ts
@@ -1,0 +1,23 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class AgentBots extends BaseSchema {
+  protected tableName = 'agent_bots';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.string('description')
+      table.string('outgoing_url')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.bigInteger('account_id')
+      table.integer('bot_type')
+      table.jsonb('bot_config')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378111_article_embeddings.ts
+++ b/adonis/database/migrations/175117047378111_article_embeddings.ts
@@ -1,0 +1,20 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ArticleEmbeddings extends BaseSchema {
+  protected tableName = 'article_embeddings';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('article_id')
+      table.text('term')
+      table.string('embedding')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378112_articles.ts
+++ b/adonis/database/migrations/175117047378112_articles.ts
@@ -1,0 +1,32 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Articles extends BaseSchema {
+  protected tableName = 'articles';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('account_id')
+      table.integer('portal_id')
+      table.integer('category_id')
+      table.integer('folder_id')
+      table.string('title')
+      table.text('description')
+      table.text('content')
+      table.integer('status')
+      table.integer('views')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.bigInteger('author_id')
+      table.bigInteger('associated_article_id')
+      table.jsonb('meta')
+      table.string('slug')
+      table.integer('position')
+      table.string('locale')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378113_attachments.ts
+++ b/adonis/database/migrations/175117047378113_attachments.ts
@@ -1,0 +1,26 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Attachments extends BaseSchema {
+  protected tableName = 'attachments';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('file_type')
+      table.string('external_url')
+      table.float('coordinates_lat')
+      table.float('coordinates_long')
+      table.integer('message_id')
+      table.integer('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.string('fallback_title')
+      table.string('extension')
+      table.jsonb('meta')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378114_audits.ts
+++ b/adonis/database/migrations/175117047378114_audits.ts
@@ -1,0 +1,29 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Audits extends BaseSchema {
+  protected tableName = 'audits';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('auditable_id')
+      table.string('auditable_type')
+      table.bigInteger('associated_id')
+      table.string('associated_type')
+      table.bigInteger('user_id')
+      table.string('user_type')
+      table.string('username')
+      table.string('action')
+      table.jsonb('audited_changes')
+      table.integer('version')
+      table.string('comment')
+      table.string('remote_address')
+      table.string('request_uuid')
+      table.timestamp('created_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378115_automation_rules.ts
+++ b/adonis/database/migrations/175117047378115_automation_rules.ts
@@ -1,0 +1,24 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class AutomationRules extends BaseSchema {
+  protected tableName = 'automation_rules';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('account_id')
+      table.string('name')
+      table.text('description')
+      table.string('event_name')
+      table.jsonb('conditions')
+      table.jsonb('actions')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.boolean('active')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378116_campaigns.ts
+++ b/adonis/database/migrations/175117047378116_campaigns.ts
@@ -1,0 +1,31 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Campaigns extends BaseSchema {
+  protected tableName = 'campaigns';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('display_id')
+      table.string('title')
+      table.text('description')
+      table.text('message')
+      table.integer('sender_id')
+      table.boolean('enabled')
+      table.bigInteger('account_id')
+      table.bigInteger('inbox_id')
+      table.jsonb('trigger_rules')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.integer('campaign_type')
+      table.integer('campaign_status')
+      table.jsonb('audience')
+      table.timestamp('scheduled_at')
+      table.boolean('trigger_only_during_business_hours')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378117_canned_responses.ts
+++ b/adonis/database/migrations/175117047378117_canned_responses.ts
@@ -1,0 +1,20 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class CannedResponses extends BaseSchema {
+  protected tableName = 'canned_responses';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('account_id')
+      table.string('short_code')
+      table.text('content')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378118_captain_assistant_responses.ts
+++ b/adonis/database/migrations/175117047378118_captain_assistant_responses.ts
@@ -1,0 +1,25 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class CaptainAssistantResponses extends BaseSchema {
+  protected tableName = 'captain_assistant_responses';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('question')
+      table.text('answer')
+      table.string('embedding')
+      table.bigInteger('assistant_id')
+      table.bigInteger('documentable_id')
+      table.bigInteger('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.integer('status')
+      table.string('documentable_type')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378219_captain_assistants.ts
+++ b/adonis/database/migrations/175117047378219_captain_assistants.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class CaptainAssistants extends BaseSchema {
+  protected tableName = 'captain_assistants';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.bigInteger('account_id')
+      table.string('description')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.jsonb('config')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378220_captain_documents.ts
+++ b/adonis/database/migrations/175117047378220_captain_documents.ts
@@ -1,0 +1,23 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class CaptainDocuments extends BaseSchema {
+  protected tableName = 'captain_documents';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.string('external_link')
+      table.text('content')
+      table.bigInteger('assistant_id')
+      table.bigInteger('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.integer('status')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378221_captain_inboxes.ts
+++ b/adonis/database/migrations/175117047378221_captain_inboxes.ts
@@ -1,0 +1,19 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class CaptainInboxes extends BaseSchema {
+  protected tableName = 'captain_inboxes';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('captain_assistant_id')
+      table.bigInteger('inbox_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378222_categories.ts
+++ b/adonis/database/migrations/175117047378222_categories.ts
@@ -1,0 +1,27 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Categories extends BaseSchema {
+  protected tableName = 'categories';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('account_id')
+      table.integer('portal_id')
+      table.string('name')
+      table.text('description')
+      table.integer('position')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.string('locale')
+      table.string('slug')
+      table.bigInteger('parent_category_id')
+      table.bigInteger('associated_category_id')
+      table.string('icon')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378223_channel_api.ts
+++ b/adonis/database/migrations/175117047378223_channel_api.ts
@@ -1,0 +1,23 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ChannelApi extends BaseSchema {
+  protected tableName = 'channel_api';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('account_id')
+      table.string('webhook_url')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.string('identifier')
+      table.string('hmac_token')
+      table.boolean('hmac_mandatory')
+      table.jsonb('additional_attributes')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378224_channel_email.ts
+++ b/adonis/database/migrations/175117047378224_channel_email.ts
@@ -1,0 +1,38 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ChannelEmail extends BaseSchema {
+  protected tableName = 'channel_email';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('account_id')
+      table.string('email')
+      table.string('forward_to_email')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.boolean('imap_enabled')
+      table.string('imap_address')
+      table.integer('imap_port')
+      table.string('imap_login')
+      table.string('imap_password')
+      table.boolean('imap_enable_ssl')
+      table.boolean('smtp_enabled')
+      table.string('smtp_address')
+      table.integer('smtp_port')
+      table.string('smtp_login')
+      table.string('smtp_password')
+      table.string('smtp_domain')
+      table.boolean('smtp_enable_starttls_auto')
+      table.string('smtp_authentication')
+      table.string('smtp_openssl_verify_mode')
+      table.boolean('smtp_enable_ssl_tls')
+      table.jsonb('provider_config')
+      table.string('provider')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378225_channel_facebook_pages.ts
+++ b/adonis/database/migrations/175117047378225_channel_facebook_pages.ts
@@ -1,0 +1,22 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ChannelFacebookPages extends BaseSchema {
+  protected tableName = 'channel_facebook_pages';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('page_id')
+      table.string('user_access_token')
+      table.string('page_access_token')
+      table.integer('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.string('instagram_id')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378226_channel_instagram.ts
+++ b/adonis/database/migrations/175117047378226_channel_instagram.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ChannelInstagram extends BaseSchema {
+  protected tableName = 'channel_instagram';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('access_token')
+      table.timestamp('expires_at')
+      table.integer('account_id')
+      table.string('instagram_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378227_channel_line.ts
+++ b/adonis/database/migrations/175117047378227_channel_line.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ChannelLine extends BaseSchema {
+  protected tableName = 'channel_line';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('account_id')
+      table.string('line_channel_id')
+      table.string('line_channel_secret')
+      table.string('line_channel_token')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378228_channel_sms.ts
+++ b/adonis/database/migrations/175117047378228_channel_sms.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ChannelSms extends BaseSchema {
+  protected tableName = 'channel_sms';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('account_id')
+      table.string('phone_number')
+      table.string('provider')
+      table.jsonb('provider_config')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378229_channel_telegram.ts
+++ b/adonis/database/migrations/175117047378229_channel_telegram.ts
@@ -1,0 +1,20 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ChannelTelegram extends BaseSchema {
+  protected tableName = 'channel_telegram';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('bot_name')
+      table.integer('account_id')
+      table.string('bot_token')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378230_channel_twilio_sms.ts
+++ b/adonis/database/migrations/175117047378230_channel_twilio_sms.ts
@@ -1,0 +1,24 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ChannelTwilioSms extends BaseSchema {
+  protected tableName = 'channel_twilio_sms';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('phone_number')
+      table.string('auth_token')
+      table.string('account_sid')
+      table.integer('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.integer('medium')
+      table.string('messaging_service_sid')
+      table.string('api_key_sid')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378231_channel_twitter_profiles.ts
+++ b/adonis/database/migrations/175117047378231_channel_twitter_profiles.ts
@@ -1,0 +1,22 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ChannelTwitterProfiles extends BaseSchema {
+  protected tableName = 'channel_twitter_profiles';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('profile_id')
+      table.string('twitter_access_token')
+      table.string('twitter_access_token_secret')
+      table.integer('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.boolean('tweets_enabled')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378232_channel_web_widgets.ts
+++ b/adonis/database/migrations/175117047378232_channel_web_widgets.ts
@@ -1,0 +1,30 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ChannelWebWidgets extends BaseSchema {
+  protected tableName = 'channel_web_widgets';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('website_url')
+      table.integer('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.string('website_token')
+      table.string('widget_color')
+      table.string('welcome_title')
+      table.string('welcome_tagline')
+      table.integer('feature_flags')
+      table.integer('reply_time')
+      table.string('hmac_token')
+      table.boolean('pre_chat_form_enabled')
+      table.jsonb('pre_chat_form_options')
+      table.boolean('hmac_mandatory')
+      table.boolean('continuity_via_email')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378233_channel_whatsapp.ts
+++ b/adonis/database/migrations/175117047378233_channel_whatsapp.ts
@@ -1,0 +1,23 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ChannelWhatsapp extends BaseSchema {
+  protected tableName = 'channel_whatsapp';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('account_id')
+      table.string('phone_number')
+      table.string('provider')
+      table.jsonb('provider_config')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.jsonb('message_templates')
+      table.timestamp('message_templates_last_updated')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378334_contact_inboxes.ts
+++ b/adonis/database/migrations/175117047378334_contact_inboxes.ts
@@ -1,0 +1,22 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ContactInboxes extends BaseSchema {
+  protected tableName = 'contact_inboxes';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('contact_id')
+      table.bigInteger('inbox_id')
+      table.string('source_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.boolean('hmac_verified')
+      table.string('pubsub_token')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378335_contacts.ts
+++ b/adonis/database/migrations/175117047378335_contacts.ts
@@ -1,0 +1,31 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Contacts extends BaseSchema {
+  protected tableName = 'contacts';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.string('email')
+      table.string('phone_number')
+      table.integer('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.jsonb('additional_attributes')
+      table.string('identifier')
+      table.jsonb('custom_attributes')
+      table.timestamp('last_activity_at')
+      table.integer('contact_type')
+      table.string('middle_name')
+      table.string('last_name')
+      table.string('location')
+      table.string('country_code')
+      table.boolean('blocked')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378336_conversation_participants.ts
+++ b/adonis/database/migrations/175117047378336_conversation_participants.ts
@@ -1,0 +1,20 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ConversationParticipants extends BaseSchema {
+  protected tableName = 'conversation_participants';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('account_id')
+      table.bigInteger('user_id')
+      table.bigInteger('conversation_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378337_conversations.ts
+++ b/adonis/database/migrations/175117047378337_conversations.ts
@@ -1,0 +1,40 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Conversations extends BaseSchema {
+  protected tableName = 'conversations';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('account_id')
+      table.integer('inbox_id')
+      table.integer('status')
+      table.integer('assignee_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.bigInteger('contact_id')
+      table.integer('display_id')
+      table.timestamp('contact_last_seen_at')
+      table.timestamp('agent_last_seen_at')
+      table.jsonb('additional_attributes')
+      table.bigInteger('contact_inbox_id')
+      table.string('uuid')
+      table.string('identifier')
+      table.timestamp('last_activity_at')
+      table.bigInteger('team_id')
+      table.bigInteger('campaign_id')
+      table.timestamp('snoozed_until')
+      table.jsonb('custom_attributes')
+      table.timestamp('assignee_last_seen_at')
+      table.timestamp('first_reply_created_at')
+      table.integer('priority')
+      table.bigInteger('sla_policy_id')
+      table.timestamp('waiting_since')
+      table.text('cached_label_list')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378338_copilot_messages.ts
+++ b/adonis/database/migrations/175117047378338_copilot_messages.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class CopilotMessages extends BaseSchema {
+  protected tableName = 'copilot_messages';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('copilot_thread_id')
+      table.bigInteger('account_id')
+      table.jsonb('message')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.integer('message_type')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378339_copilot_threads.ts
+++ b/adonis/database/migrations/175117047378339_copilot_threads.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class CopilotThreads extends BaseSchema {
+  protected tableName = 'copilot_threads';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('title')
+      table.bigInteger('user_id')
+      table.bigInteger('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.integer('assistant_id')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378340_csat_survey_responses.ts
+++ b/adonis/database/migrations/175117047378340_csat_survey_responses.ts
@@ -1,0 +1,24 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class CsatSurveyResponses extends BaseSchema {
+  protected tableName = 'csat_survey_responses';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('account_id')
+      table.bigInteger('conversation_id')
+      table.bigInteger('message_id')
+      table.integer('rating')
+      table.text('feedback_message')
+      table.bigInteger('contact_id')
+      table.bigInteger('assigned_agent_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378341_custom_attribute_definitions.ts
+++ b/adonis/database/migrations/175117047378341_custom_attribute_definitions.ts
@@ -1,0 +1,27 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class CustomAttributeDefinitions extends BaseSchema {
+  protected tableName = 'custom_attribute_definitions';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('attribute_display_name')
+      table.string('attribute_key')
+      table.integer('attribute_display_type')
+      table.integer('default_value')
+      table.integer('attribute_model')
+      table.bigInteger('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.text('attribute_description')
+      table.jsonb('attribute_values')
+      table.string('regex_pattern')
+      table.string('regex_cue')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378342_custom_filters.ts
+++ b/adonis/database/migrations/175117047378342_custom_filters.ts
@@ -1,0 +1,22 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class CustomFilters extends BaseSchema {
+  protected tableName = 'custom_filters';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.integer('filter_type')
+      table.jsonb('query')
+      table.bigInteger('account_id')
+      table.bigInteger('user_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378343_custom_roles.ts
+++ b/adonis/database/migrations/175117047378343_custom_roles.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class CustomRoles extends BaseSchema {
+  protected tableName = 'custom_roles';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.string('description')
+      table.bigInteger('account_id')
+      table.text('permissions')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378344_dashboard_apps.ts
+++ b/adonis/database/migrations/175117047378344_dashboard_apps.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class DashboardApps extends BaseSchema {
+  protected tableName = 'dashboard_apps';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('title')
+      table.jsonb('content')
+      table.bigInteger('account_id')
+      table.bigInteger('user_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378345_data_imports.ts
+++ b/adonis/database/migrations/175117047378345_data_imports.ts
@@ -1,0 +1,23 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class DataImports extends BaseSchema {
+  protected tableName = 'data_imports';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('account_id')
+      table.string('data_type')
+      table.integer('status')
+      table.text('processing_errors')
+      table.integer('total_records')
+      table.integer('processed_records')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378346_email_templates.ts
+++ b/adonis/database/migrations/175117047378346_email_templates.ts
@@ -1,0 +1,22 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class EmailTemplates extends BaseSchema {
+  protected tableName = 'email_templates';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.text('body')
+      table.integer('account_id')
+      table.integer('template_type')
+      table.integer('locale')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378347_folders.ts
+++ b/adonis/database/migrations/175117047378347_folders.ts
@@ -1,0 +1,20 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Folders extends BaseSchema {
+  protected tableName = 'folders';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('account_id')
+      table.integer('category_id')
+      table.string('name')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378348_inbox_members.ts
+++ b/adonis/database/migrations/175117047378348_inbox_members.ts
@@ -1,0 +1,19 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class InboxMembers extends BaseSchema {
+  protected tableName = 'inbox_members';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('user_id')
+      table.integer('inbox_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378349_inboxes.ts
+++ b/adonis/database/migrations/175117047378349_inboxes.ts
@@ -1,0 +1,37 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Inboxes extends BaseSchema {
+  protected tableName = 'inboxes';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('channel_id')
+      table.integer('account_id')
+      table.string('name')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.string('channel_type')
+      table.boolean('enable_auto_assignment')
+      table.boolean('greeting_enabled')
+      table.string('greeting_message')
+      table.string('email_address')
+      table.boolean('working_hours_enabled')
+      table.string('out_of_office_message')
+      table.string('timezone')
+      table.boolean('enable_email_collect')
+      table.boolean('csat_survey_enabled')
+      table.boolean('allow_messages_after_resolved')
+      table.jsonb('auto_assignment_config')
+      table.boolean('lock_to_single_conversation')
+      table.bigInteger('portal_id')
+      table.integer('sender_name_type')
+      table.string('business_name')
+      table.jsonb('csat_config')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378350_installation_configs.ts
+++ b/adonis/database/migrations/175117047378350_installation_configs.ts
@@ -1,0 +1,20 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class InstallationConfigs extends BaseSchema {
+  protected tableName = 'installation_configs';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.jsonb('serialized_value')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.boolean('locked')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378451_integrations_hooks.ts
+++ b/adonis/database/migrations/175117047378451_integrations_hooks.ts
@@ -1,0 +1,25 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class IntegrationsHooks extends BaseSchema {
+  protected tableName = 'integrations_hooks';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('status')
+      table.integer('inbox_id')
+      table.integer('account_id')
+      table.string('app_id')
+      table.integer('hook_type')
+      table.string('reference_id')
+      table.string('access_token')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.jsonb('settings')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378452_labels.ts
+++ b/adonis/database/migrations/175117047378452_labels.ts
@@ -1,0 +1,22 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Labels extends BaseSchema {
+  protected tableName = 'labels';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('title')
+      table.text('description')
+      table.string('color')
+      table.boolean('show_on_sidebar')
+      table.bigInteger('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378453_macros.ts
+++ b/adonis/database/migrations/175117047378453_macros.ts
@@ -1,0 +1,23 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Macros extends BaseSchema {
+  protected tableName = 'macros';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('account_id')
+      table.string('name')
+      table.integer('visibility')
+      table.bigInteger('created_by_id')
+      table.bigInteger('updated_by_id')
+      table.jsonb('actions')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378454_mentions.ts
+++ b/adonis/database/migrations/175117047378454_mentions.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Mentions extends BaseSchema {
+  protected tableName = 'mentions';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('user_id')
+      table.bigInteger('conversation_id')
+      table.bigInteger('account_id')
+      table.timestamp('mentioned_at')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378455_messages.ts
+++ b/adonis/database/migrations/175117047378455_messages.ts
@@ -1,0 +1,33 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Messages extends BaseSchema {
+  protected tableName = 'messages';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.text('content')
+      table.integer('account_id')
+      table.integer('inbox_id')
+      table.integer('conversation_id')
+      table.integer('message_type')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.boolean('private')
+      table.integer('status')
+      table.string('source_id')
+      table.integer('content_type')
+      table.string('content_attributes')
+      table.string('sender_type')
+      table.bigInteger('sender_id')
+      table.jsonb('external_source_ids')
+      table.jsonb('additional_attributes')
+      table.text('processed_message_content')
+      table.jsonb('sentiment')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378456_notes.ts
+++ b/adonis/database/migrations/175117047378456_notes.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Notes extends BaseSchema {
+  protected tableName = 'notes';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.text('content')
+      table.bigInteger('account_id')
+      table.bigInteger('contact_id')
+      table.bigInteger('user_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378457_notification_settings.ts
+++ b/adonis/database/migrations/175117047378457_notification_settings.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class NotificationSettings extends BaseSchema {
+  protected tableName = 'notification_settings';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('account_id')
+      table.integer('user_id')
+      table.integer('email_flags')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.integer('push_flags')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378458_notification_subscriptions.ts
+++ b/adonis/database/migrations/175117047378458_notification_subscriptions.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class NotificationSubscriptions extends BaseSchema {
+  protected tableName = 'notification_subscriptions';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('user_id')
+      table.integer('subscription_type')
+      table.jsonb('subscription_attributes')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.text('identifier')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378459_notifications.ts
+++ b/adonis/database/migrations/175117047378459_notifications.ts
@@ -1,0 +1,28 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Notifications extends BaseSchema {
+  protected tableName = 'notifications';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('account_id')
+      table.bigInteger('user_id')
+      table.integer('notification_type')
+      table.string('primary_actor_type')
+      table.bigInteger('primary_actor_id')
+      table.string('secondary_actor_type')
+      table.bigInteger('secondary_actor_id')
+      table.timestamp('read_at')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.timestamp('snoozed_until')
+      table.timestamp('last_activity_at')
+      table.jsonb('meta')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378460_platform_app_permissibles.ts
+++ b/adonis/database/migrations/175117047378460_platform_app_permissibles.ts
@@ -1,0 +1,20 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class PlatformAppPermissibles extends BaseSchema {
+  protected tableName = 'platform_app_permissibles';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('platform_app_id')
+      table.string('permissible_type')
+      table.bigInteger('permissible_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378461_platform_apps.ts
+++ b/adonis/database/migrations/175117047378461_platform_apps.ts
@@ -1,0 +1,18 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class PlatformApps extends BaseSchema {
+  protected tableName = 'platform_apps';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378462_portals.ts
+++ b/adonis/database/migrations/175117047378462_portals.ts
@@ -1,0 +1,28 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Portals extends BaseSchema {
+  protected tableName = 'portals';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('account_id')
+      table.string('name')
+      table.string('slug')
+      table.string('custom_domain')
+      table.string('color')
+      table.string('homepage_link')
+      table.string('page_title')
+      table.text('header_text')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.jsonb('config')
+      table.boolean('archived')
+      table.bigInteger('channel_web_widget_id')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378463_portals_members.ts
+++ b/adonis/database/migrations/175117047378463_portals_members.ts
@@ -1,0 +1,17 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class PortalsMembers extends BaseSchema {
+  protected tableName = 'portals_members';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('portal_id')
+      table.bigInteger('user_id')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378464_related_categories.ts
+++ b/adonis/database/migrations/175117047378464_related_categories.ts
@@ -1,0 +1,19 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class RelatedCategories extends BaseSchema {
+  protected tableName = 'related_categories';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('category_id')
+      table.bigInteger('related_category_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378465_reporting_events.ts
+++ b/adonis/database/migrations/175117047378465_reporting_events.ts
@@ -1,0 +1,26 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class ReportingEvents extends BaseSchema {
+  protected tableName = 'reporting_events';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.float('value')
+      table.integer('account_id')
+      table.integer('inbox_id')
+      table.integer('user_id')
+      table.integer('conversation_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.float('value_in_business_hours')
+      table.timestamp('event_start_time')
+      table.timestamp('event_end_time')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378466_sla_events.ts
+++ b/adonis/database/migrations/175117047378466_sla_events.ts
@@ -1,0 +1,24 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class SlaEvents extends BaseSchema {
+  protected tableName = 'sla_events';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('applied_sla_id')
+      table.bigInteger('conversation_id')
+      table.bigInteger('account_id')
+      table.bigInteger('sla_policy_id')
+      table.bigInteger('inbox_id')
+      table.integer('event_type')
+      table.jsonb('meta')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378467_sla_policies.ts
+++ b/adonis/database/migrations/175117047378467_sla_policies.ts
@@ -1,0 +1,24 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class SlaPolicies extends BaseSchema {
+  protected tableName = 'sla_policies';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.float('first_response_time_threshold')
+      table.float('next_response_time_threshold')
+      table.boolean('only_during_business_hours')
+      table.bigInteger('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.string('description')
+      table.float('resolution_time_threshold')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378568_taggings.ts
+++ b/adonis/database/migrations/175117047378568_taggings.ts
@@ -1,0 +1,22 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Taggings extends BaseSchema {
+  protected tableName = 'taggings';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('tag_id')
+      table.string('taggable_type')
+      table.integer('taggable_id')
+      table.string('tagger_type')
+      table.integer('tagger_id')
+      table.string('context')
+      table.timestamp('created_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378569_tags.ts
+++ b/adonis/database/migrations/175117047378569_tags.ts
@@ -1,0 +1,17 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Tags extends BaseSchema {
+  protected tableName = 'tags';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.integer('taggings_count')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378570_team_members.ts
+++ b/adonis/database/migrations/175117047378570_team_members.ts
@@ -1,0 +1,19 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class TeamMembers extends BaseSchema {
+  protected tableName = 'team_members';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('team_id')
+      table.bigInteger('user_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378571_teams.ts
+++ b/adonis/database/migrations/175117047378571_teams.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Teams extends BaseSchema {
+  protected tableName = 'teams';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.text('description')
+      table.boolean('allow_auto_assign')
+      table.bigInteger('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378672_telegram_bots.ts
+++ b/adonis/database/migrations/175117047378672_telegram_bots.ts
@@ -1,0 +1,20 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class TelegramBots extends BaseSchema {
+  protected tableName = 'telegram_bots';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('name')
+      table.string('auth_key')
+      table.integer('account_id')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378673_users.ts
+++ b/adonis/database/migrations/175117047378673_users.ts
@@ -1,0 +1,42 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Users extends BaseSchema {
+  protected tableName = 'users';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('provider')
+      table.string('uid')
+      table.string('encrypted_password')
+      table.string('reset_password_token')
+      table.timestamp('reset_password_sent_at')
+      table.timestamp('remember_created_at')
+      table.integer('sign_in_count')
+      table.timestamp('current_sign_in_at')
+      table.timestamp('last_sign_in_at')
+      table.string('current_sign_in_ip')
+      table.string('last_sign_in_ip')
+      table.string('confirmation_token')
+      table.timestamp('confirmed_at')
+      table.timestamp('confirmation_sent_at')
+      table.string('unconfirmed_email')
+      table.string('name')
+      table.string('display_name')
+      table.string('email')
+      table.string('tokens')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.string('pubsub_token')
+      table.integer('availability')
+      table.jsonb('ui_settings')
+      table.jsonb('custom_attributes')
+      table.string('type')
+      table.text('message_signature')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378674_webhooks.ts
+++ b/adonis/database/migrations/175117047378674_webhooks.ts
@@ -1,0 +1,22 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Webhooks extends BaseSchema {
+  protected tableName = 'webhooks';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.integer('account_id')
+      table.integer('inbox_id')
+      table.string('url')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.integer('webhook_type')
+      table.jsonb('subscriptions')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/adonis/database/migrations/175117047378675_working_hours.ts
+++ b/adonis/database/migrations/175117047378675_working_hours.ts
@@ -1,0 +1,26 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class WorkingHours extends BaseSchema {
+  protected tableName = 'working_hours';
+
+  public async up () {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('inbox_id')
+      table.bigInteger('account_id')
+      table.integer('day_of_week')
+      table.boolean('closed_all_day')
+      table.integer('open_hour')
+      table.integer('open_minutes')
+      table.integer('close_hour')
+      table.integer('close_minutes')
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+      table.boolean('open_all_day')
+    })
+  }
+
+  public async down () {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/scripts/generate_adonis_migrations.js
+++ b/scripts/generate_adonis_migrations.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+
+const schemaPath = path.join(__dirname, '../db/schema.rb');
+const schema = fs.readFileSync(schemaPath, 'utf8').split('\n');
+
+const migrationsDir = path.join(__dirname, '../adonis/database/migrations');
+const modelsDir = path.join(__dirname, '../adonis/app/Models');
+fs.mkdirSync(migrationsDir, { recursive: true });
+fs.mkdirSync(modelsDir, { recursive: true });
+
+function pascalCase(str) {
+  return str
+    .split('_')
+    .map(s => s.charAt(0).toUpperCase() + s.slice(1))
+    .join('');
+}
+
+function mapType(type) {
+  switch (type) {
+    case 'string': return 'string';
+    case 'bigint': return 'bigInteger';
+    case 'integer': return 'integer';
+    case 'text': return 'text';
+    case 'boolean': return 'boolean';
+    case 'datetime': return 'timestamp';
+    case 'jsonb': return 'jsonb';
+    case 'float': return 'float';
+    case 'decimal': return 'decimal';
+    default: return 'string';
+  }
+}
+
+let i = 0;
+let index = 1;
+while (i < schema.length) {
+  const line = schema[i];
+  const match = line.match(/create_table \"([\w_]+)\"/);
+  if (match) {
+    const tableName = match[1];
+    const columns = [];
+    i++;
+    while (i < schema.length && !schema[i].startsWith('  end')) {
+      const colMatch = schema[i].match(/t\.([\w]+) \"([\w_]+)\"/);
+      if (colMatch) {
+        columns.push({ type: colMatch[1], name: colMatch[2] });
+      }
+      i++;
+    }
+    const timestamp = `${Date.now()}${index}`;
+    const migrationFile = path.join(migrationsDir, `${timestamp}_${tableName}.ts`);
+    const upLines = [];
+    upLines.push("import BaseSchema from '@ioc:Adonis/Lucid/Schema'");
+    upLines.push('');
+    upLines.push(`export default class ${pascalCase(tableName)} extends BaseSchema {`);
+    upLines.push('  protected tableName = \'' + tableName + '\';');
+    upLines.push('');
+    upLines.push('  public async up () {');
+    upLines.push('    this.schema.createTable(this.tableName, (table) => {');
+    upLines.push("      table.increments('id')");
+    columns.forEach(c => {
+      const colType = mapType(c.type);
+      upLines.push(`      table.${colType}('${c.name}')`);
+    });
+    upLines.push('    })');
+    upLines.push('  }');
+    upLines.push('');
+    upLines.push('  public async down () {');
+    upLines.push('    this.schema.dropTable(this.tableName)');
+    upLines.push('  }');
+    upLines.push('}');
+    fs.writeFileSync(migrationFile, upLines.join('\n'));
+
+    const modelFile = path.join(modelsDir, `${pascalCase(tableName)}.ts`);
+    const modelLines = [];
+    modelLines.push("import { BaseModel, column } from '@ioc:Adonis/Lucid/Orm'");
+    modelLines.push('');
+    modelLines.push(`export default class ${pascalCase(tableName)} extends BaseModel {`);
+    modelLines.push('  public static table = \'' + tableName + '\';');
+    modelLines.push('');
+    modelLines.push('  @column({ isPrimary: true })');
+    modelLines.push('  public id: number');
+    modelLines.push('}');
+    fs.writeFileSync(modelFile, modelLines.join('\n'));
+    index++;
+  }
+  i++;
+}


### PR DESCRIPTION
## Summary
- introduce `scripts/generate_adonis_migrations.js` to parse Rails schema and output AdonisJS migrations and models
- generate AdonisJS migration files under `adonis/database/migrations`
- generate AdonisJS model files under `adonis/app/Models`

## Testing
- `pnpm eslint`
- `bundle exec rubocop -a`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6860bd48e2288333b252e76a550c3cc4